### PR TITLE
Claude plugin fixes

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,16 +1,18 @@
 {
-  "skills": [
+  "name": "slidecrafting",
+  "owner": {
+    "name": "Emil Hvitfeldt",
+    "url": "https://github.com/EmilHvitfeldt/slidecrafting.com"
+  },
+  "metadata": {
+    "description": "Skills for building beautiful Quarto reveal.js slide decks, from slidecrafting-book.com.",
+    "version": "0.1.0"
+  },
+  "plugins": [
     {
-      "name": "quarto-revealjs",
-      "path": "./skills/quarto-revealjs"
-    },
-    {
-      "name": "quarto-revealjs-fragment",
-      "path": "./skills/quarto-revealjs-fragment"
-    },
-    {
-      "name": "auto-animate-elements",
-      "path": "./skills/auto-animate-elements"
+      "name": "slidecrafting",
+      "source": ".",
+      "description": "Build, theme, animate, and present Quarto reveal.js slide decks. Bundles three skills: quarto-revealjs (router with 43 references), quarto-revealjs-fragment, and auto-animate-elements."
     }
   ]
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,0 +1,15 @@
+{
+  "name": "slidecrafting",
+  "description": "Build, theme, animate, and present Quarto reveal.js slide decks. Bundles three skills: quarto-revealjs (router with 43 references), quarto-revealjs-fragment, and auto-animate-elements.",
+  "version": "0.1.0",
+  "author": {
+    "name": "Emil Hvitfeldt"
+  },
+  "homepage": "https://slidecrafting-book.com",
+  "repository": "https://github.com/emilhvitfeldt/slidecrafting.com",
+  "skills": [
+    "./skills/quarto-revealjs",
+    "./skills/quarto-revealjs-fragment",
+    "./skills/auto-animate-elements"
+  ]
+}

--- a/skills/auto-animate-elements/SKILL.md
+++ b/skills/auto-animate-elements/SKILL.md
@@ -1,6 +1,6 @@
 ---
-name: auto-animate-elements
-description: How to spruce up Quarto reveal.js slides with auto-animate by carrying a small cast of persistent elements (shapes) across slides that grow, shrink, and rearrange. Use this skill whenever the user wants elements that persist/animate/reshape between reveal.js slides, a set of shapes that move or morph across a deck, an "auto-animate" motif, or a bento-style animated presentation in Quarto. Covers the data-id contract, the SCSS-plus-inline split, content and figures inside elements, and the "enough, not all" pacing rule.
+name: "auto-animate-elements"
+description: 'How to spruce up Quarto reveal.js slides with auto-animate by carrying a small cast of persistent elements (shapes) across slides that grow, shrink, and rearrange. Use this skill whenever the user wants elements that persist/animate/reshape between reveal.js slides, a set of shapes that move or morph across a deck, an "auto-animate" motif, or a bento-style animated presentation in Quarto. Covers the data-id contract, the SCSS-plus-inline split, content and figures inside elements, and the "enough, not all" pacing rule.'
 ---
 
 # Auto-Animate persistent elements

--- a/skills/quarto-revealjs-fragment/SKILL.md
+++ b/skills/quarto-revealjs-fragment/SKILL.md
@@ -1,6 +1,6 @@
 ---
-name: quarto-revealjs-fragment
-description: How to create custom Reveal.js fragment animations in Quarto presentations. Use this skill whenever the user wants to add a custom animated fragment effect to a Quarto revealjs slide — things like letters falling, elements fading in unusually, text that animates on a keypress, or any effect tied to Reveal.js fragment navigation. Covers the div syntax, CSS states, JS events, and mid-animation reversal patterns.
+name: "quarto-revealjs-fragment"
+description: "How to create custom Reveal.js fragment animations in Quarto presentations. Use this skill whenever the user wants to add a custom animated fragment effect to a Quarto revealjs slide — things like letters falling, elements fading in unusually, text that animates on a keypress, or any effect tied to Reveal.js fragment navigation. Covers the div syntax, CSS states, JS events, and mid-animation reversal patterns."
 ---
 
 # Custom Quarto Reveal.js Fragments

--- a/skills/quarto-revealjs/SKILL.md
+++ b/skills/quarto-revealjs/SKILL.md
@@ -1,6 +1,6 @@
 ---
-name: quarto-revealjs
-description: Build, theme, and present reveal.js slide decks authored in Quarto. Use this skill whenever the user is working on Quarto reveal.js slides (a `.qmd` with `format: revealjs`) - starting a new deck, restyling it (fonts, colors, sizes, SCSS themes), positioning content (columns, absolute positioning, background images, overlays, cards), showing code or plots well, adding fragment or auto-animate motion, or presenting and exporting (speaker notes, speaker view, PDF, chalkboard, multiplex). Routes to focused reference files under references/.
+name: "quarto-revealjs"
+description: "Build, theme, and present reveal.js slide decks authored in Quarto. Use this skill whenever the user is working on Quarto reveal.js slides (a `.qmd` with `format: revealjs`) - starting a new deck, restyling it (fonts, colors, sizes, SCSS themes), positioning content (columns, absolute positioning, background images, overlays, cards), showing code or plots well, adding fragment or auto-animate motion, or presenting and exporting (speaker notes, speaker view, PDF, chalkboard, multiplex). Routes to focused reference files under references/."
 ---
 
 # Quarto Reveal.js — beautiful slides


### PR DESCRIPTION
Hey there, @EmilHvitfeldt!

I was attempting to use the Claude Code plugin, but was having issues due to missing metadata:
```
❯ /plugin marketplace add emilhvitfeldt/slidecrafting.com                                                                     
  ⎿  Error: Failed to parse marketplace file at
     /home/<username>/.claude/plugins/marketplaces/emilhvitfeldt-slidecrafting-com/.claude-plugin/marketplace.json:
     Invalid schema:
     /home/<username>/.claude/plugins/marketplaces/emilhvitfeldt-slidecrafting-com/.claude-plugin/marketplace.json name:
     Invalid input: expected string, received undefined, owner: Invalid input: expected object, received undefined, plugins:
     Invalid input: expected array, received undefined
```

This PR updates the structure so that the Claude Code plugin/marketplace will fully install rather than install and then fail Claude Code's validation step when installing into via `/plugin marketplace add emilhvitfeldt/slidecrafting.com`:

- Added a `plugin.json` file and updates the `marketplace.json` file; updated both with required metadata and other metadata to avoid validation warnings
    - Note: I set the version to `0.1.0` - will leave it up to you whether this is a good place to start or if you want to set another version number (or remove it and just ignore the warning during validation)
- Wrapped content in quotes in the YAML header for all 3 `SKILL.md` files so that the YAML content is hidden when viewing as a rendered markdown file 
    - When I tried to upload the skills manually, the `auto-animate-elements` skill was throwing an error, saying `SKILL.md frontmatter missing name or description` - this was caused by there being some double quotes in the middle of the description. The easy fix was just wrap the entire description in that skill file in single quotes. Just wanted to call this out so you're adamant about not having the YAML content in quotes for some reason


Looking forward to playing around with the skills you've made!

Cheers